### PR TITLE
Auto find latest Fedora image for download. Fixes #3

### DIFF
--- a/.env
+++ b/.env
@@ -7,7 +7,8 @@ PP_PARTB=/dev/loop1p2
 OUT_NAME=fedora.img
 
 # Only needed if you want a custom file, otherwise do not change.
-FEDORA_RAW_FILE=Fedora-Minimal-Rawhide-20200302.n.1.aarch64.raw.xz
+# FEDORA_RAW_FILE=Fedora-Minimal-Rawhide-20200302.n.1.aarch64.raw.xz
+FEDORA_RAW_SOURCE=https://dl.fedoraproject.org/pub/fedora-secondary/development/rawhide/Spins/aarch64/images
 KERNEL_RAW_DIR=pp-5.6
 
 export PP_IMAGE

--- a/.env
+++ b/.env
@@ -16,4 +16,5 @@ export PP_PARTA
 export PP_PARTB
 export OUT_NAME
 export FEDORA_RAW_FILE
+export FEDORA_RAW_SOURCE
 export KERNEL_RAW_DIR

--- a/02-install-rootfs.sh
+++ b/02-install-rootfs.sh
@@ -16,11 +16,6 @@ errecho () {
     exit 1
 }
 
-# Ask for env vars...
-infecho "The env vars that will be used in this script..."
-infecho "FEDORA_RAW_FILE = $FEDORA_RAW_FILE"
-echo
-
 # Automatic Preflight Checks
 if [[ $EUID -ne 0 ]]; then
     errecho "This script must be run as root!" 

--- a/download-files.sh
+++ b/download-files.sh
@@ -3,9 +3,6 @@ set -e
 
 source .env
 
-echo "This may fail! This is because it is set to download a file that is too old."
-echo "Please visit https://dl.fedoraproject.org/pub/fedora-secondary/development/rawhide/Spins/aarch64/images/ and update the file name in .env with the new file name on that website."
-
 echo "This script will download a few GB of Fedora and a few MB of Kernel into the current directory."
 echo "Look inside the script if you would rather download manually."
 echo
@@ -17,7 +14,28 @@ then
     wget https://xff.cz/kernels/5.6/pp.tar.gz -O pp.tar.gz
     tar xf pp.tar.gz
 
+    # Get latest rawhide from repo when not set in .env
+    if [ -z "$FEDORA_RAW_FILE" ]
+    then
+        echo "Searching for latest Fedora Rawhide..."
+        FEDORA_RAW_VER=$(wget -q $FEDORA_RAW_SOURCE -O - | grep -Po '(?<=Fedora-Minimal-Rawhide-).*?(?=.aarch64)' | head -n 1)
+        if [ ! -z "$FEDORA_RAW_VER" ]
+        then
+            echo "Downloading latest Fedora version: $FEDORA_RAW_VER"
+            FEDORA_RAW_FILE=Fedora-Minimal-Rawhide-$FEDORA_RAW_VER.aarch64.raw.xz
+            echo ""
+        else
+            echo "Could not obtain latest version data"
+            echo "Please visit $FEDORA_RAW_SOURCE uncomment and update the FEDORA_RAW_FILE name in .env with the name on that website."
+            exit 1
+        fi
+    else
+        echo "Downloading Fedora set in .env file: $FEDORA_RAW_FILE"
+        echo "This may fail if it is set to download a file that is too old."
+        echo ""
+    fi
+
     # Download fedora
-    wget https://dl.fedoraproject.org/pub/fedora-secondary/development/rawhide/Spins/aarch64/images/$FEDORA_RAW_FILE -O rawhide.raw.xz
+    wget $FEDORA_RAW_SOURCE/$FEDORA_RAW_FILE -O rawhide.raw.xz
     xz --decompress rawhide.raw.xz
 fi


### PR DESCRIPTION
With this change the download script will use wget to obtain the latest Fedora Rawhide version from download repo. Manually changing the requested version in .env is no longer needed.

I have kept the old approach anyway in case the auto obtain method fails for some reason (but should work unless Fedora versioning system will change) in which case user will be notified to uncomment the variable in .env and set it manually like it had to be done until now.