### PR TITLE
Add missing dependency

### DIFF
--- a/00-selftest.sh
+++ b/00-selftest.sh
@@ -10,6 +10,10 @@ echo "=============="
 infecho () {
     echo "[Info] $1"
 }
+errecho () {
+    echo "[Error] $1" 1>&2
+    exit 1
+}
 
 infecho "Now running selftest, please do not continue running scripts until this completes successfully."
 
@@ -19,6 +23,7 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 command -v mkfs.f2fs >/dev/null 2>&1 || { echo >&2 "I require mkfs.f2fs but it's not installed.  Aborting."; exit 1; }
+command -v mkfs.vfat >/dev/null 2>&1 || { echo >&2 "I require mkfs.vfat but it's not installed.  Aborting."; exit 1; }
 command -v qemu-aarch64-static >/dev/null 2>&1 || { echo >&2 "I require qemu-aarch64-static but it's not installed.  Aborting."; exit 1; }
 command -v rsync >/dev/null 2>&1 || { echo >&2 "I require rsync but it's not installed.  Aborting."; exit 1; }
 command -v mkimage >/dev/null 2>&1 || { echo >&2 "I require mkimage but it's not installed.  Aborting."; exit 1; }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a **barely tested** collection of scripts written by someone who has nev
 - wget
 - xz
 - f2fs-tools (for mkfs.f2fs)
+- dosfstools (for mkfs.vfat)
 - rsync
 - uboot-tools (for mkimage)
 - qemu-user-static (for qemu-aarch64-static)


### PR DESCRIPTION
mkfs.vfat is provided by dosfstools (On Fedora)