### PR TITLE
Set system chassis to handset

### DIFF
--- a/04-edit-fstab.sh
+++ b/04-edit-fstab.sh
@@ -48,6 +48,9 @@ then
     touch rootfs/usr/share/glib-2.0/schemas/files/90_pinephone.gschema.override
     cat files/90_pinephone.gschema.override > rootfs/usr/share/glib-2.0/schemas/files/90_pinephone.gschema.override
 
+    infecho "Setting system chassis..."
+    cat files/machine-info > rootfs/etc/machine-info
+
     infecho "Unmounting root file system..."
     sleep 3
     umount $PP_PARTB

--- a/04-edit-fstab.sh
+++ b/04-edit-fstab.sh
@@ -48,9 +48,6 @@ then
     touch rootfs/usr/share/glib-2.0/schemas/files/90_pinephone.gschema.override
     cat files/90_pinephone.gschema.override > rootfs/usr/share/glib-2.0/schemas/files/90_pinephone.gschema.override
 
-    infecho "Setting system chassis..."
-    cat files/machine-info > rootfs/etc/machine-info
-
     infecho "Unmounting root file system..."
     sleep 3
     umount $PP_PARTB

--- a/files/machine-info
+++ b/files/machine-info
@@ -1,0 +1,1 @@
+CHASSIS=handset

--- a/files/machine-info
+++ b/files/machine-info
@@ -1,1 +1,0 @@
-CHASSIS=handset

--- a/phone-scripts/02-install-packages.sh
+++ b/phone-scripts/02-install-packages.sh
@@ -43,9 +43,6 @@ systemctl disable initial-setup.service
 systemctl enable lightdm
 systemctl set-default graphical.target
 
-infecho "Setting system chassis..."
-hostnamectl set-chassis handset
-
 infecho "Making COPR higher priority for kernel updates..."
 echo "priority=10" >> /etc/yum.repos.d/_copr\:copr.fedorainfracloud.org\:njha\:mobile.repo
 

--- a/phone-scripts/02-install-packages.sh
+++ b/phone-scripts/02-install-packages.sh
@@ -43,6 +43,9 @@ systemctl disable initial-setup.service
 systemctl enable lightdm
 systemctl set-default graphical.target
 
+infecho "Setting system chassis..."
+hostnamectl set-chassis handset
+
 infecho "Making COPR higher priority for kernel updates..."
 echo "priority=10" >> /etc/yum.repos.d/_copr\:copr.fedorainfracloud.org\:njha\:mobile.repo
 


### PR DESCRIPTION
The current image suffers from the problem of the system chassis not being set to "handset".  This results in Phosh starting in docked mode.

By changing the default chassis to "handset", Phosh will only support docked mode when plugged into a monitor and with a mouse: the intended behaviour.

Fixes #73.