### PR TITLE
Allocate image as a sparse 6GB file

### DIFF
--- a/00-create-empty-image.sh
+++ b/00-create-empty-image.sh
@@ -7,12 +7,20 @@ echo "========================"
 echo "00-create-empty-image.sh"
 echo "========================"
 
-# Approximately 3GB image.
-echo "Create image called $OUT_NAME? Make sure this doesn't exist, or it will be zeroed out."
+# Approximately 6GB image.
+echo "Create image called $OUT_NAME? Make sure this doesn't exist, or it will be replaced."
 read -p "Continue? [y/N] " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    echo "Creating blank 3GB file called $OUT_NAME."
-    dd if=/dev/zero of=$OUT_NAME iflag=fullblock bs=1M count=4400 && sync
+    if [[ -e "$OUT_NAME" ]]
+    then
+        echo "Removing pre-existing $OUT_NAME."
+        unlink $OUT_NAME
+    fi
+
+    # Create this as a sparse file
+    echo "Creating sparse blank 6GB file called $OUT_NAME."
+    dd if=/dev/zero of=$OUT_NAME bs=1 count=0 seek=6G && sync
+
 fi


### PR DESCRIPTION
Allocate the image file as a sparse file, instead of pre-allocating several GB of zeroes. This makes it easier to create larger images as well, without actually impacting on-disk image size.

Because this won't erase the previous file with zeroes, specifically remove it (using `unlink`) before creating a new sparse file.

Additionally, increased the image size to 6GB. No impact to actual on-disk usage, but while testing the create script, 3GB was insufficient. I imagine the smallest SD card expected to test this image on a pinephone would be 8GB anyway, so there should be minimal impact to this change.