### PR TITLE
Set defaults with overrides

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 # These will be created, make sure they don't exist already!
 # Set defaults, but allow them to be overridden
 PP_IMAGE=${PP_IMAGE:-/dev/loop1}
-PP_PARTA=${PP_PARTA:-/dev/loop1p1}
-PP_PARTB=${PP_PARTB:-/dev/loop1p2}
+PP_PARTA=${PP_PARTA:-${PP_IMAGE}p1}
+PP_PARTB=${PP_PARTB:-${PP_IMAGE}p2}
 
 # Output file name.
 OUT_NAME=${OUT_NAME:-fedora.img}

--- a/.env
+++ b/.env
@@ -1,15 +1,16 @@
 # These will be created, make sure they don't exist already!
-PP_IMAGE=/dev/loop1
-PP_PARTA=/dev/loop1p1
-PP_PARTB=/dev/loop1p2
+# Set defaults, but allow them to be overridden
+PP_IMAGE=${PP_IMAGE:-/dev/loop1}
+PP_PARTA=${PP_PARTA:-/dev/loop1p1}
+PP_PARTB=${PP_PARTB:-/dev/loop1p2}
 
 # Output file name.
-OUT_NAME=fedora.img
+OUT_NAME=${OUT_NAME:-fedora.img}
 
 # Only needed if you want a custom file, otherwise do not change.
 # FEDORA_RAW_FILE=Fedora-Minimal-Rawhide-20200302.n.1.aarch64.raw.xz
-FEDORA_RAW_SOURCE=https://dl.fedoraproject.org/pub/fedora-secondary/development/rawhide/Spins/aarch64/images
-KERNEL_RAW_DIR=pp1-5.7
+FEDORA_RAW_SOURCE=${EFDORA_RAW_SOURCE:-https://dl.fedoraproject.org/pub/fedora-secondary/development/rawhide/Spins/aarch64/images}
+KERNEL_RAW_DIR=${KERNEL_RAW_DIR:-pp1-5.7}
 
 export PP_IMAGE
 export PP_PARTA

--- a/01-partition-drive.sh
+++ b/01-partition-drive.sh
@@ -41,9 +41,9 @@ unit: sectors
 EOF
     infecho "Image partitioned!"
 
-    infecho "Mounting the image to loop1..."
-    losetup /dev/loop1 fedora.img
-    partprobe -s /dev/loop1
+    infecho "Mounting the image to ${PP_IMAGE}..."
+    losetup "${PP_IMAGE}" fedora.img
+    partprobe -s "${PP_IMAGE}"
 
     infecho "Beginning filesystem creation..."
     infecho "If this fails, you might need to install mkfs.btrfs."


### PR DESCRIPTION
Values in the `.env` file were required to be manually modified. This doesn't allow for them to be easily overridden. This PR allows values in the .env file to be overridden by environment variables, for instance in a CI environment.

It also corrects an instance where a value was able to be defined in .env but was still hardcoded into the script.