### PR TITLE
Eliminate -ne for string compare

### DIFF
--- a/00-selftest.sh
+++ b/00-selftest.sh
@@ -27,7 +27,7 @@ fi
 command -v mkfs.btrfs >/dev/null 2>&1 || { echo >&2 "I require mkfs.btrfs but it's not installed.  Aborting."; exit 1; }
 command -v mkfs.vfat >/dev/null 2>&1 || { echo >&2 "I require mkfs.vfat but it's not installed.  Aborting."; exit 1; }
 
-if [[ $HOSTARCH -ne "aarch64" ]]; then
+if [[ $HOSTARCH != "aarch64" ]]; then
     command -v qemu-aarch64-static >/dev/null 2>&1 || { echo >&2 "I require qemu-aarch64-static but it's not installed.  Aborting."; exit 1; }
 fi
 

--- a/05-setup-user.sh
+++ b/05-setup-user.sh
@@ -43,7 +43,7 @@ then
     mkdir -p rootfs/boot
     mount $PP_PARTA rootfs/boot
 
-    if [[ $HOSTARCH -ne "aarch64" ]]; then
+    if [[ $HOSTARCH != "aarch64" ]]; then
         infecho "Installing qemu in rootfs..."
         cp /usr/bin/qemu-aarch64-static rootfs/usr/bin
     fi
@@ -57,7 +57,7 @@ then
     infecho "Copy resolv.conf /etc/tmp-resolv.conf"
     cp /etc/resolv.conf rootfs/etc/tmp-resolv.conf
 
-    if [[ $HOSTARCH -ne "aarch64" ]]; then
+    if [[ $HOSTARCH != "aarch64" ]]; then
         infecho "Chrooting with qemu into rootfs..."
         chroot rootfs qemu-aarch64-static /bin/bash /root/all.sh
 


### PR DESCRIPTION
In bash, the `-ne` operator can only operate on numeric values. Therefore, since both "x86_64" and "aarch64" parse to the integer value "0", these tests were always evaluating as `false`, even if the builds were done on an x86_64 machine.